### PR TITLE
Refactor AccessInspector responsibilities

### DIFF
--- a/spec/PhpSpec/CodeAnalysis/MagicAwareAccessInspectorSpec.php
+++ b/spec/PhpSpec/CodeAnalysis/MagicAwareAccessInspectorSpec.php
@@ -2,20 +2,21 @@
 
 namespace spec\PhpSpec\CodeAnalysis;
 
+use Phpspec\CodeAnalysis\AccessInspectorInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use spec\PhpSpec\Listener\DoubleOfStdClass;
 
 class MagicAwareAccessInspectorSpec extends ObjectBehavior
 {
+    function let(AccessInspectorInterface $accessInspector)
+    {
+        $this->beConstructedWith($accessInspector);
+    }
+
     function it_should_be_an_access_inspector()
     {
         $this->shouldImplement('PhpSpec\CodeAnalysis\AccessInspectorInterface');
-    }
-
-    function it_should_fail_to_check_for_a_property_of_a_non_object()
-    {
-        $this->isPropertyReadable('foo', 'property')->shouldReturn(false);
-        $this->isPropertyWritable('foo', 'property')->shouldReturn(false);
     }
 
     function it_should_detect_a_magic_getter_if_no_value_is_given()
@@ -28,47 +29,51 @@ class MagicAwareAccessInspectorSpec extends ObjectBehavior
         $this->isPropertyWritable(new ObjectWithMagicSet, 'property', true)->shouldReturn(true);
     }
 
-    function it_should_reject_an_object_if_the_property_does_not_exist()
-    {
-        $this->isPropertyReadable(new ObjectWithNoProperty, 'property')->shouldReturn(false);
-        $this->isPropertyWritable(new ObjectWithNoProperty, 'property')->shouldReturn(false);
-    }
-
-    function it_should_reject_a_private_property()
-    {
-        $this->isPropertyReadable(new ObjectWithPrivateProperty, 'property')->shouldReturn(false);
-        $this->isPropertyWritable(new ObjectWithPrivateProperty, 'property')->shouldReturn(false);
-    }
-
-    function it_should_detect_a_public_property()
-    {
-        $this->isPropertyReadable(new ObjectWithPublicProperty, 'property')->shouldReturn(true);
-        $this->isPropertyWritable(new ObjectWithPublicProperty, 'property')->shouldReturn(true);
-    }
-
-    function it_should_fail_to_check_for_a_method_of_a_non_object()
-    {
-        $this->isMethodCallable('foo', 'method')->shouldReturn(false);
-    }
-
     function it_should_detect_a_magic_call_method()
     {
         $this->isMethodCallable(new ObjectWithMagicCall, 'method')->shouldreturn(true);
     }
 
-    function it_should_reject_an_object_if_a_method_does_not_exist()
+    function it_should_not_detect_a_getter_if_there_is_no_magic_getter_and_wrapped_inspector_finds_none(AccessInspectorInterface $accessInspector)
     {
-        $this->isMethodCallable(new ObjectWithNoMethod, 'method')->shouldReturn(false);
+        $accessInspector->isPropertyReadable(new \StdClass(), 'foo')->willReturn(false);
+
+        $this->isPropertyReadable(new \StdClass(), 'foo')->shouldReturn(false);
     }
 
-    function it_should_reject_a_private_method()
+    function it_should_detect_a_getter_if_there_is_no_magic_getter_but_wrapped_inspector_finds_one(AccessInspectorInterface $accessInspector)
     {
-        $this->isMethodCallable(new ObjectWithPrivateMethod, 'method')->shouldReturn(false);
+        $accessInspector->isPropertyReadable(new \StdClass(), 'foo')->willReturn(true);
+
+        $this->isPropertyReadable(new \StdClass(), 'foo')->shouldReturn(true);
     }
 
-    function it_should_detect_a_public_method()
+    function it_should_not_detect_a_setter_if_there_is_no_magic_setter_and_wrapped_inspector_finds_none(AccessInspectorInterface $accessInspector)
     {
-        $this->isMethodCallable(new ObjectWithPublicMethod, 'method')->shouldReturn(true);
+        $accessInspector->isPropertyWritable(new \StdClass(), 'foo')->willReturn(false);
+
+        $this->isPropertyWritable(new \StdClass(), 'foo')->shouldReturn(false);
+    }
+
+    function it_should_detect_a_setter_if_there_is_no_magic_setter_but_wrapped_inspector_finds_one(AccessInspectorInterface $accessInspector)
+    {
+        $accessInspector->isPropertyWritable(new \StdClass(), 'foo')->willReturn(true);
+
+        $this->isPropertyWritable(new \StdClass(), 'foo')->shouldReturn(true);
+    }
+
+    function it_should_detect_a_method_if_there_is_no_magic_caller_and_wrapped_inspector_finds_none(AccessInspectorInterface $accessInspector)
+    {
+        $accessInspector->isMethodCallable(new \StdClass(), 'foo')->willReturn(false);
+
+        $this->isMethodCallable(new \StdClass(), 'foo')->shouldReturn(false);
+    }
+
+    function it_should_detect_a_method_if_there_is_no_magic_caller_but_wrapped_inspector_finds_one(AccessInspectorInterface $accessInspector)
+    {
+        $accessInspector->isMethodCallable(new \StdClass(), 'foo')->willReturn(true);
+
+        $this->isMethodCallable(new \StdClass(), 'foo')->shouldReturn(true);
     }
 }
 
@@ -86,41 +91,9 @@ class ObjectWithMagicSet
     }
 }
 
-class ObjectWithNoProperty
-{
-}
-
-class ObjectWithPrivateProperty
-{
-    private $property;
-}
-
-class ObjectWithPublicProperty
-{
-    public $property;
-}
-
 class ObjectWithMagicCall
 {
     public function __call($name, $args)
-    {
-    }
-}
-
-class ObjectWithNoMethod
-{
-}
-
-class ObjectWithPrivateMethod
-{
-    private function method()
-    {
-    }
-}
-
-class ObjectWithPublicMethod
-{
-    public function method()
     {
     }
 }

--- a/spec/PhpSpec/CodeAnalysis/MagicAwareAccessInspectorSpec.php
+++ b/spec/PhpSpec/CodeAnalysis/MagicAwareAccessInspectorSpec.php
@@ -14,57 +14,61 @@ class MagicAwareAccessInspectorSpec extends ObjectBehavior
 
     function it_should_fail_to_check_for_a_property_of_a_non_object()
     {
-        $this->isPropertyAccessible('foo', 'property')->shouldReturn(false);
+        $this->isPropertyReadable('foo', 'property')->shouldReturn(false);
+        $this->isPropertyWritable('foo', 'property')->shouldReturn(false);
     }
 
     function it_should_detect_a_magic_getter_if_no_value_is_given()
     {
-        $this->isPropertyAccessible(new ObjectWithMagicGet, 'property')->shouldReturn(true);
+        $this->isPropertyReadable(new ObjectWithMagicGet, 'property')->shouldReturn(true);
     }
 
     function it_should_detect_a_magic_setter_if_a_value_is_given()
     {
-        $this->isPropertyAccessible(new ObjectWithMagicSet, 'property', true)->shouldReturn(true);
+        $this->isPropertyWritable(new ObjectWithMagicSet, 'property', true)->shouldReturn(true);
     }
 
     function it_should_reject_an_object_if_the_property_does_not_exist()
     {
-        $this->isPropertyAccessible(new ObjectWithNoProperty, 'property')->shouldReturn(false);
+        $this->isPropertyReadable(new ObjectWithNoProperty, 'property')->shouldReturn(false);
+        $this->isPropertyWritable(new ObjectWithNoProperty, 'property')->shouldReturn(false);
     }
 
     function it_should_reject_a_private_property()
     {
-        $this->isPropertyAccessible(new ObjectWithPrivateProperty, 'property')->shouldReturn(false);
+        $this->isPropertyReadable(new ObjectWithPrivateProperty, 'property')->shouldReturn(false);
+        $this->isPropertyWritable(new ObjectWithPrivateProperty, 'property')->shouldReturn(false);
     }
 
     function it_should_detect_a_public_property()
     {
-        $this->isPropertyAccessible(new ObjectWithPublicProperty, 'property')->shouldReturn(true);
+        $this->isPropertyReadable(new ObjectWithPublicProperty, 'property')->shouldReturn(true);
+        $this->isPropertyWritable(new ObjectWithPublicProperty, 'property')->shouldReturn(true);
     }
 
     function it_should_fail_to_check_for_a_method_of_a_non_object()
     {
-        $this->isMethodAccessible('foo', 'method')->shouldReturn(false);
+        $this->isMethodCallable('foo', 'method')->shouldReturn(false);
     }
 
     function it_should_detect_a_magic_call_method()
     {
-        $this->isMethodAccessible(new ObjectWithMagicCall, 'method')->shouldreturn(true);
+        $this->isMethodCallable(new ObjectWithMagicCall, 'method')->shouldreturn(true);
     }
 
     function it_should_reject_an_object_if_a_method_does_not_exist()
     {
-        $this->isMethodAccessible(new ObjectWithNoMethod, 'method')->shouldReturn(false);
+        $this->isMethodCallable(new ObjectWithNoMethod, 'method')->shouldReturn(false);
     }
 
     function it_should_reject_a_private_method()
     {
-        $this->isMethodAccessible(new ObjectWithPrivateMethod, 'method')->shouldReturn(false);
+        $this->isMethodCallable(new ObjectWithPrivateMethod, 'method')->shouldReturn(false);
     }
 
     function it_should_detect_a_public_method()
     {
-        $this->isMethodAccessible(new ObjectWithPublicMethod, 'method')->shouldReturn(true);
+        $this->isMethodCallable(new ObjectWithPublicMethod, 'method')->shouldReturn(true);
     }
 }
 

--- a/spec/PhpSpec/CodeAnalysis/VisibilityAccessInspectorSpec.php
+++ b/spec/PhpSpec/CodeAnalysis/VisibilityAccessInspectorSpec.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace spec\PhpSpec\CodeAnalysis;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class VisibilityAccessInspectorSpec extends ObjectBehavior
+{
+    function it_should_be_an_access_inspector()
+    {
+        $this->shouldImplement('PhpSpec\CodeAnalysis\AccessInspectorInterface');
+    }
+
+    function it_should_reject_an_object_if_the_property_does_not_exist()
+    {
+        $this->isPropertyReadable(new ObjectWithNoProperty, 'property')->shouldReturn(false);
+        $this->isPropertyWritable(new ObjectWithNoProperty, 'property')->shouldReturn(false);
+    }
+
+    function it_should_reject_a_private_property()
+    {
+        $this->isPropertyReadable(new ObjectWithPrivateProperty, 'property')->shouldReturn(false);
+        $this->isPropertyWritable(new ObjectWithPrivateProperty, 'property')->shouldReturn(false);
+    }
+
+    function it_should_detect_a_public_property()
+    {
+        $this->isPropertyReadable(new ObjectWithPublicProperty, 'property')->shouldReturn(true);
+        $this->isPropertyWritable(new ObjectWithPublicProperty, 'property')->shouldReturn(true);
+    }
+
+    function it_should_reject_an_object_if_a_method_does_not_exist()
+    {
+        $this->isMethodCallable(new ObjectWithNoMethod, 'method')->shouldReturn(false);
+    }
+
+    function it_should_reject_a_private_method()
+    {
+        $this->isMethodCallable(new ObjectWithPrivateMethod, 'method')->shouldReturn(false);
+    }
+
+    function it_should_detect_a_public_method()
+    {
+        $this->isMethodCallable(new ObjectWithPublicMethod, 'method')->shouldReturn(true);
+    }
+
+}
+
+class ObjectWithNoProperty
+{
+}
+
+class ObjectWithPrivateProperty
+{
+    private $property;
+}
+
+class ObjectWithPublicProperty
+{
+    public $property;
+}
+
+class ObjectWithNoMethod
+{
+}
+
+class ObjectWithPrivateMethod
+{
+    private function method()
+    {
+    }
+}
+
+class ObjectWithPublicMethod
+{
+    public function method()
+    {
+    }
+}

--- a/spec/PhpSpec/Wrapper/Subject/CallerSpec.php
+++ b/spec/PhpSpec/Wrapper/Subject/CallerSpec.php
@@ -30,7 +30,7 @@ class CallerSpec extends ObjectBehavior
         $wrappedObject->isInstantiated()->willReturn(true);
         $wrappedObject->getInstance()->willReturn(new \ArrayObject());
 
-        $accessInspector->isMethodAccessible(Argument::type('ArrayObject'), 'count')->willReturn(true);
+        $accessInspector->isMethodCallable(Argument::type('ArrayObject'), 'count')->willReturn(true);
 
         $dispatcher->dispatch(
             'beforeMethodCall',
@@ -51,8 +51,8 @@ class CallerSpec extends ObjectBehavior
         $obj = new \stdClass();
         $obj->id = 1;
 
-        $accessInspector->isPropertyAccessible(
-            Argument::type('stdClass'), 'id', true
+        $accessInspector->isPropertyWritable(
+            Argument::type('stdClass'), 'id'
         )->willReturn('true');
 
         $wrappedObject->isInstantiated()->willReturn(true);
@@ -69,7 +69,7 @@ class CallerSpec extends ObjectBehavior
         $wrappedObject->isInstantiated()->willReturn(true);
         $wrappedObject->getInstance()->willReturn($obj);
 
-        $accessInspector->isMethodAccessible(Argument::type('ArrayObject'), 'asort')->willReturn(true);
+        $accessInspector->isMethodCallable(Argument::type('ArrayObject'), 'asort')->willReturn(true);
 
         $this->call('asort');
     }

--- a/src/PhpSpec/CodeAnalysis/AccessInspectorInterface.php
+++ b/src/PhpSpec/CodeAnalysis/AccessInspectorInterface.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Phpspec\CodeAnalysis;
 
 interface AccessInspectorInterface

--- a/src/PhpSpec/CodeAnalysis/AccessInspectorInterface.php
+++ b/src/PhpSpec/CodeAnalysis/AccessInspectorInterface.php
@@ -7,15 +7,24 @@ interface AccessInspectorInterface
     /**
      * @param object $object
      * @param string $property
-     * @param bool $withValue
+     *
      * @return bool
      */
-    public function isPropertyAccessible($object, $property, $withValue);
+    public function isPropertyReadable($object, $property);
+
+    /**
+     * @param object $object
+     * @param string $property
+     *
+     * @return bool
+     */
+    public function isPropertyWritable($object, $property);
 
     /**
      * @param object $object
      * @param string $method
+     *
      * @return bool
      */
-    public function isMethodAccessible($object, $method);
+    public function isMethodCallable($object, $method);
 }

--- a/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
+++ b/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
@@ -15,20 +15,7 @@ final class MagicAwareAccessInspector implements AccessInspectorInterface
      */
     public function isPropertyReadable($object, $property)
     {
-        if (!is_object($object)) {
-            return false;
-        }
-
-        if (method_exists($object, '__get')) {
-            return true;
-        }
-
-        if (!property_exists($object, $property)) {
-            return false;
-        }
-
-        $propertyReflection = new ReflectionProperty($object, $property);
-        return $propertyReflection->isPublic();
+        return is_object($object) && (method_exists($object, '__get') || $this->isExistingPublicProperty($object, $property));
     }
 
     /**
@@ -39,20 +26,7 @@ final class MagicAwareAccessInspector implements AccessInspectorInterface
      */
     public function isPropertyWritable($object, $property)
     {
-        if (!is_object($object)) {
-            return false;
-        }
-
-        if (method_exists($object, '__set')) {
-            return true;
-        }
-
-        if (!property_exists($object, $property)) {
-            return false;
-        }
-
-        $propertyReflection = new ReflectionProperty($object, $property);
-        return $propertyReflection->isPublic();
+        return is_object($object) && (method_exists($object, '__set') || $this->isExistingPublicProperty($object, $property));
     }
 
     /**
@@ -63,19 +37,40 @@ final class MagicAwareAccessInspector implements AccessInspectorInterface
      */
     public function isMethodCallable($object, $method)
     {
-        if (!is_object($object)) {
+        return is_object($object) && (method_exists($object, '__call') || $this->isExistingPublicMethod($object, $method));
+    }
+
+    /**
+     * @param object $object
+     * @param string $property
+     *
+     * @return bool
+     */
+    private function isExistingPublicProperty($object, $property)
+    {
+        if (!property_exists($object, $property)) {
             return false;
         }
 
-        if (method_exists($object, '__call')) {
-            return true;
-        }
+        $propertyReflection = new ReflectionProperty($object, $property);
 
+        return $propertyReflection->isPublic();
+    }
+
+    /**
+     * @param object $object
+     * @param string $method
+     *
+     * @return bool
+     */
+    private function isExistingPublicMethod($object, $method)
+    {
         if (!method_exists($object, $method)) {
             return false;
         }
 
         $methodReflection = new ReflectionMethod($object, $method);
+
         return $methodReflection->isPublic();
     }
 }

--- a/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
+++ b/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
@@ -15,7 +15,7 @@ final class MagicAwareAccessInspector implements AccessInspectorInterface
      */
     public function isPropertyReadable($object, $property)
     {
-        return is_object($object) && (method_exists($object, '__get') || $this->isExistingPublicProperty($object, $property));
+        return (method_exists($object, '__get') || $this->isExistingPublicProperty($object, $property));
     }
 
     /**
@@ -26,7 +26,7 @@ final class MagicAwareAccessInspector implements AccessInspectorInterface
      */
     public function isPropertyWritable($object, $property)
     {
-        return is_object($object) && (method_exists($object, '__set') || $this->isExistingPublicProperty($object, $property));
+        return(method_exists($object, '__set') || $this->isExistingPublicProperty($object, $property));
     }
 
     /**
@@ -37,7 +37,7 @@ final class MagicAwareAccessInspector implements AccessInspectorInterface
      */
     public function isMethodCallable($object, $method)
     {
-        return is_object($object) && (method_exists($object, '__call') || $this->isExistingPublicMethod($object, $method));
+        return (method_exists($object, '__call') || $this->isExistingPublicMethod($object, $method));
     }
 
     /**

--- a/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
+++ b/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace PhpSpec\CodeAnalysis;
 
 use ReflectionMethod;
@@ -8,6 +19,19 @@ use ReflectionProperty;
 final class MagicAwareAccessInspector implements AccessInspectorInterface
 {
     /**
+     * @var AccessInspectorInterface
+     */
+    private $accessInspector;
+
+    /**
+     * @param AccessInspectorInterface $accessInspector
+     */
+    public function __construct(AccessInspectorInterface $accessInspector)
+    {
+        $this->accessInspector = $accessInspector;
+    }
+
+    /**
      * @param object $object
      * @param string $property
      *
@@ -15,7 +39,7 @@ final class MagicAwareAccessInspector implements AccessInspectorInterface
      */
     public function isPropertyReadable($object, $property)
     {
-        return (method_exists($object, '__get') || $this->isExistingPublicProperty($object, $property));
+        return method_exists($object, '__get') || $this->accessInspector->isPropertyReadable($object, $property);
     }
 
     /**
@@ -26,7 +50,7 @@ final class MagicAwareAccessInspector implements AccessInspectorInterface
      */
     public function isPropertyWritable($object, $property)
     {
-        return(method_exists($object, '__set') || $this->isExistingPublicProperty($object, $property));
+        return method_exists($object, '__set') || $this->accessInspector->isPropertyWritable($object, $property);
     }
 
     /**
@@ -37,40 +61,6 @@ final class MagicAwareAccessInspector implements AccessInspectorInterface
      */
     public function isMethodCallable($object, $method)
     {
-        return (method_exists($object, '__call') || $this->isExistingPublicMethod($object, $method));
-    }
-
-    /**
-     * @param object $object
-     * @param string $property
-     *
-     * @return bool
-     */
-    private function isExistingPublicProperty($object, $property)
-    {
-        if (!property_exists($object, $property)) {
-            return false;
-        }
-
-        $propertyReflection = new ReflectionProperty($object, $property);
-
-        return $propertyReflection->isPublic();
-    }
-
-    /**
-     * @param object $object
-     * @param string $method
-     *
-     * @return bool
-     */
-    private function isExistingPublicMethod($object, $method)
-    {
-        if (!method_exists($object, $method)) {
-            return false;
-        }
-
-        $methodReflection = new ReflectionMethod($object, $method);
-
-        return $methodReflection->isPublic();
+        return method_exists($object, '__call') || $this->accessInspector->isMethodCallable($object, $method);
     }
 }

--- a/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
+++ b/src/PhpSpec/CodeAnalysis/MagicAwareAccessInspector.php
@@ -10,16 +10,40 @@ final class MagicAwareAccessInspector implements AccessInspectorInterface
     /**
      * @param object $object
      * @param string $property
-     * @param bool $withValue
+     *
      * @return bool
      */
-    public function isPropertyAccessible($object, $property, $withValue = false)
+    public function isPropertyReadable($object, $property)
     {
         if (!is_object($object)) {
             return false;
         }
 
-        if (method_exists($object, $withValue ? '__set' : '__get')) {
+        if (method_exists($object, '__get')) {
+            return true;
+        }
+
+        if (!property_exists($object, $property)) {
+            return false;
+        }
+
+        $propertyReflection = new ReflectionProperty($object, $property);
+        return $propertyReflection->isPublic();
+    }
+
+    /**
+     * @param object $object
+     * @param string $property
+     *
+     * @return bool
+     */
+    public function isPropertyWritable($object, $property)
+    {
+        if (!is_object($object)) {
+            return false;
+        }
+
+        if (method_exists($object, '__set')) {
             return true;
         }
 
@@ -34,9 +58,10 @@ final class MagicAwareAccessInspector implements AccessInspectorInterface
     /**
      * @param object $object
      * @param string $method
+     *
      * @return bool
      */
-    public function isMethodAccessible($object, $method)
+    public function isMethodCallable($object, $method)
     {
         if (!is_object($object)) {
             return false;

--- a/src/PhpSpec/CodeAnalysis/VisibilityAccessInspector.php
+++ b/src/PhpSpec/CodeAnalysis/VisibilityAccessInspector.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of PhpSpec, A php toolset to drive emergent
+ * design by specification.
+ *
+ * (c) Marcello Duarte <marcello.duarte@gmail.com>
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpSpec\CodeAnalysis;
+
+use ReflectionMethod;
+use ReflectionProperty;
+
+final class VisibilityAccessInspector implements AccessInspectorInterface
+{
+    /**
+     * @param object $object
+     * @param string $property
+     *
+     * @return bool
+     */
+    public function isPropertyReadable($object, $property)
+    {
+        return $this->isExistingPublicProperty($object, $property);
+    }
+
+    /**
+     * @param object $object
+     * @param string $property
+     *
+     * @return bool
+     */
+    public function isPropertyWritable($object, $property)
+    {
+        return $this->isExistingPublicProperty($object, $property);
+    }
+
+    /**
+     * @param object $object
+     * @param string $property
+     *
+     * @return bool
+     */
+    private function isExistingPublicProperty($object, $property)
+    {
+        if (!property_exists($object, $property)) {
+            return false;
+        }
+
+        $propertyReflection = new ReflectionProperty($object, $property);
+
+        return $propertyReflection->isPublic();
+    }
+
+    /**
+     * @param object $object
+     * @param string $method
+     *
+     * @return bool
+     */
+    public function isMethodCallable($object, $method)
+    {
+        return $this->isExistingPublicMethod($object, $method);
+    }
+
+    /**
+     * @param object $object
+     * @param string $method
+     *
+     * @return bool
+     */
+    private function isExistingPublicMethod($object, $method)
+    {
+        if (!method_exists($object, $method)) {
+            return false;
+        }
+
+        $methodReflection = new ReflectionMethod($object, $method);
+
+        return $methodReflection->isPublic();
+    }
+}

--- a/src/PhpSpec/Console/ContainerAssembler.php
+++ b/src/PhpSpec/Console/ContainerAssembler.php
@@ -14,6 +14,7 @@
 namespace PhpSpec\Console;
 
 use PhpSpec\CodeAnalysis\MagicAwareAccessInspector;
+use PhpSpec\CodeAnalysis\VisibilityAccessInspector;
 use SebastianBergmann\Exporter\Exporter;
 use PhpSpec\Process\ReRunner;
 use PhpSpec\Util\MethodAnalyser;
@@ -533,8 +534,16 @@ class ContainerAssembler
             return new Wrapper\Unwrapper();
         });
 
-        $container->setShared('access_inspector', function() {
-            return new MagicAwareAccessInspector();
+        $container->setShared('access_inspector', function($c) {
+            return $c->get('access_inspector.magic');
+        });
+
+        $container->setShared('access_inspector.magic', function($c) {
+            return new MagicAwareAccessInspector($c->get('access_inspector.visibility'));
+        });
+
+        $container->setShared('access_inspector.visibility', function() {
+            return new VisibilityAccessInspector();
         });
     }
 

--- a/src/PhpSpec/Wrapper/Subject/Caller.php
+++ b/src/PhpSpec/Wrapper/Subject/Caller.php
@@ -15,6 +15,7 @@ namespace PhpSpec\Wrapper\Subject;
 
 use PhpSpec\CodeAnalysis\MagicAwareAccessInspector;
 use Phpspec\CodeAnalysis\AccessInspectorInterface;
+use PhpSpec\CodeAnalysis\VisibilityAccessInspector;
 use PhpSpec\Exception\ExceptionFactory;
 use PhpSpec\Loader\Node\ExampleNode;
 use PhpSpec\Wrapper\Subject;
@@ -73,7 +74,7 @@ class Caller
         $this->dispatcher       = $dispatcher;
         $this->wrapper          = $wrapper;
         $this->exceptionFactory = $exceptions;
-        $this->accessInspector  = $accessInspector ?: new MagicAwareAccessInspector();
+        $this->accessInspector  = $accessInspector ?: new MagicAwareAccessInspector(new VisibilityAccessInspector());
     }
 
     /**

--- a/src/PhpSpec/Wrapper/Subject/Caller.php
+++ b/src/PhpSpec/Wrapper/Subject/Caller.php
@@ -96,7 +96,7 @@ class Caller
         $unwrapper = new Unwrapper();
         $arguments = $unwrapper->unwrapAll($arguments);
 
-        if ($this->isObjectMethodAccessible($method)) {
+        if ($this->isObjectMethodCallable($method)) {
             return $this->invokeAndWrapMethodResult($subject, $method, $arguments);
         }
 
@@ -121,7 +121,7 @@ class Caller
         $unwrapper = new Unwrapper();
         $value = $unwrapper->unwrapOne($value);
 
-        if ($this->isObjectPropertyAccessible($property, true)) {
+        if ($this->isObjectPropertyWritable($property)) {
             return $this->getWrappedObject()->$property = $value;
         }
 
@@ -146,7 +146,7 @@ class Caller
             throw $this->accessingPropertyOnNonObject($property);
         }
 
-        if ($this->isObjectPropertyAccessible($property)) {
+        if ($this->isObjectPropertyReadable($property)) {
             return $this->wrap($this->getWrappedObject()->$property);
         }
 
@@ -186,13 +186,22 @@ class Caller
 
     /**
      * @param string $property
-     * @param bool   $withValue
      *
      * @return bool
      */
-    private function isObjectPropertyAccessible($property, $withValue = false)
+    private function isObjectPropertyReadable($property)
     {
-        return $this->accessInspector->isPropertyAccessible($this->getWrappedObject(), $property, $withValue);
+        return $this->accessInspector->isPropertyReadable($this->getWrappedObject(), $property);
+    }
+
+    /**
+     * @param string $property
+     *
+     * @return bool
+     */
+    private function isObjectPropertyWritable($property)
+    {
+        return $this->accessInspector->isPropertyWritable($this->getWrappedObject(), $property);
     }
 
     /**
@@ -200,9 +209,9 @@ class Caller
      *
      * @return bool
      */
-    private function isObjectMethodAccessible($method)
+    private function isObjectMethodCallable($method)
     {
-        return $this->accessInspector->isMethodAccessible($this->getWrappedObject(), $method);
+        return $this->accessInspector->isMethodCallable($this->getWrappedObject(), $method);
     }
 
     /**

--- a/src/PhpSpec/Wrapper/Subject/Caller.php
+++ b/src/PhpSpec/Wrapper/Subject/Caller.php
@@ -191,7 +191,9 @@ class Caller
      */
     private function isObjectPropertyReadable($property)
     {
-        return $this->accessInspector->isPropertyReadable($this->getWrappedObject(), $property);
+        $subject = $this->getWrappedObject();
+
+        return is_object($subject) && $this->accessInspector->isPropertyReadable($subject, $property);
     }
 
     /**
@@ -201,7 +203,9 @@ class Caller
      */
     private function isObjectPropertyWritable($property)
     {
-        return $this->accessInspector->isPropertyWritable($this->getWrappedObject(), $property);
+        $subject = $this->getWrappedObject();
+
+        return is_object($subject) && $this->accessInspector->isPropertyWritable($subject, $property);
     }
 
     /**


### PR DESCRIPTION
- Spit into VisibilityAccessInspector + decorating MagicAwareAccessInspector
- Move is_object responsibility back into Caller
- Separate methods for whether properties are readable or writable
